### PR TITLE
CMake Library Export, master branch (2021.10.28.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ endif()
 
 project(dfelibs VERSION 20200416 LANGUAGES CXX)
 
+# CMake include(s).
+include(GNUInstallDirs)
+
 # options are on by default if build directly, i.e. not via add_subdirectory
 option(dfelibs_BUILD_EXAMPLES "Build examples" ${dfelibs_MASTER_PROJECT})
 option(dfelibs_BUILD_UNITTESTS "Build unit tests" ${dfelibs_MASTER_PROJECT})
@@ -21,12 +24,36 @@ set(CMAKE_CXX_EXTENSIONS off)
 
 # define header-only library
 add_library(dfelibs INTERFACE)
-target_include_directories(dfelibs INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(dfelibs INTERFACE
+   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 target_compile_features(dfelibs INTERFACE cxx_std_14)
+add_library(dfelibs::dfelibs ALIAS dfelibs)
 
 if(dfelibs_ENABLE_INSTALL)
-  include(GNUInstallDirs)
   install(DIRECTORY dfe DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  install(TARGETS dfelibs EXPORT dfelibs-exports)
+
+  include(CMakePackageConfigHelpers)
+  set(CMAKE_INSTALL_CMAKEDIR
+    "${CMAKE_INSTALL_LIBDIR}/cmake/dfelibs-${PROJECT_VERSION}")
+  install(EXPORT dfelibs-exports
+    NAMESPACE "dfelibs::"
+    FILE "dfelibs-config-targets.cmake"
+    DESTINATION "${CMAKE_INSTALL_CMAKEDIR}")
+  configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/dfelibs-config.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/dfelibs-config.cmake"
+    INSTALL_DESTINATION "${CMAKE_INSTALL_CMAKEDIR}"
+    PATH_VARS CMAKE_INSTALL_INCLUDEDIR CMAKE_INSTALL_CMAKEDIR
+    NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+  write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/dfelibs-config-version.cmake"
+    COMPATIBILITY "AnyNewerVersion")
+  install( FILES
+    "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/dfelibs-config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/dfelibs-config-version.cmake"
+    DESTINATION "${CMAKE_INSTALL_CMAKEDIR}")
 endif()
 
 # optional components

--- a/cmake/dfelibs-config.cmake.in
+++ b/cmake/dfelibs-config.cmake.in
@@ -1,0 +1,23 @@
+# DFE library, part of the ACTS project
+#
+# (c) 2021 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Set up the helper functions/macros.
+@PACKAGE_INIT@
+
+# Set up some simple variables for using the package.
+set(dfelibs_VERSION "@PROJECT_VERSION@")
+set_and_check(dfelibs_INCLUDE_DIR
+  "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
+set_and_check(dfelibs_CMAKE_DIR "@PACKAGE_CMAKE_INSTALL_CMAKEDIR@")
+
+# Print a standard information message about the package being found.
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(dfelibs REQUIRED_VARS
+   CMAKE_CURRENT_LIST_FILE
+   VERSION_VAR dfelibs_VERSION)
+
+# Include the file listing all the imported targets and options.
+include("${dfelibs_CMAKE_DIR}/dfelibs-config-targets.cmake")


### PR DESCRIPTION
Taught the project how to export its CMake configuration. Which is necessary if we want to install these headers together with another project, say [detray](https://github.com/acts-project/detray), and have that other project's configuration be able to refer to these headers correctly.

The code is taken directly from https://github.com/acts-project/detray/pull/129. That PR will be simplified if/when this goes in.

Pinging @paulgessinger.