### PR TITLE
Windows Compatibility, master branch (2023.10.11.)

### DIFF
--- a/dfe/dfe_flat.hpp
+++ b/dfe/dfe_flat.hpp
@@ -170,7 +170,7 @@ template<typename T, typename Compare, typename Container>
 inline void
 FlatSet<T, Compare, Container>::insert_or_assign(const T& t) {
   auto pos = std::lower_bound(m_items.begin(), m_items.end(), t, Compare());
-  if (((pos != m_items.end()) and !Compare()(t, *pos))) {
+  if (((pos != m_items.end()) && !Compare()(t, *pos))) {
     *pos = t;
   } else {
     m_items.emplace(pos, t);
@@ -184,7 +184,7 @@ FlatSet<T, Compare, Container>::find(U&& u) const {
   auto end = m_items.end();
   auto pos =
     std::lower_bound(m_items.begin(), end, std::forward<U>(u), Compare());
-  return ((pos != end) and !Compare()(std::forward<U>(u), *pos)) ? pos : end;
+  return ((pos != end) && !Compare()(std::forward<U>(u), *pos)) ? pos : end;
 }
 
 template<typename T, typename Compare, typename Container>

--- a/dfe/dfe_io_dsv.hpp
+++ b/dfe/dfe_io_dsv.hpp
@@ -80,7 +80,7 @@ private:
   template<typename T>
   static std::enable_if_t<
     std::is_arithmetic<std::decay_t<T>>::value
-      or std::is_convertible<T, std::string>::value,
+      || std::is_convertible<T, std::string>::value,
     unsigned>
   write(T&& x, std::ostream& os);
   template<typename T, typename Allocator>
@@ -264,7 +264,7 @@ inline DsvWriter<Delimiter>::DsvWriter(
   : m_file(
     path, std::ios_base::binary | std::ios_base::out | std::ios_base::trunc)
   , m_num_columns(columns.size()) {
-  if (not m_file.is_open() or m_file.fail()) {
+  if (!m_file.is_open() || m_file.fail()) {
     throw std::runtime_error("Could not open file '" + path + "'");
   }
   m_file.precision(precision);
@@ -308,7 +308,7 @@ DsvWriter<Delimiter>::append(Arg0&& arg0, Args&&... args) {
   }
   // write the line to disk and check that it actually happened
   m_file << line.rdbuf();
-  if (not m_file.good()) {
+  if (!m_file.good()) {
     throw std::runtime_error("Could not write data to file");
   }
 }
@@ -317,7 +317,7 @@ template<char Delimiter>
 template<typename T>
 inline std::enable_if_t<
   std::is_arithmetic<std::decay_t<T>>::value
-    or std::is_convertible<T, std::string>::value,
+    || std::is_convertible<T, std::string>::value,
   unsigned>
 DsvWriter<Delimiter>::write(T&& x, std::ostream& os) {
   os << x;
@@ -345,7 +345,7 @@ DsvWriter<Delimiter>::write(
 template<char Delimiter>
 inline DsvReader<Delimiter>::DsvReader(const std::string& path)
   : m_file(path, std::ios_base::binary | std::ios_base::in) {
-  if (not m_file.is_open() or m_file.fail()) {
+  if (!m_file.is_open() || m_file.fail()) {
     throw std::runtime_error("Could not open file '" + path + "'");
   }
 }
@@ -389,12 +389,12 @@ inline NamedTupleDsvReader<Delimiter, NamedTuple>::NamedTupleDsvReader(
   bool verify_header)
   : m_reader(path) {
   // optional columns only work if we verify the header
-  if ((not optional_columns.empty()) and (not verify_header)) {
+  if ((!optional_columns.empty()) && (!verify_header)) {
     throw std::runtime_error(
       "Optional columns can not be used without header verification");
   }
   // first line is always the header
-  if (not m_reader.read(m_columns)) {
+  if (!m_reader.read(m_columns)) {
     throw std::runtime_error("Could not read header from '" + path + "'");
   }
   if (verify_header) {
@@ -407,7 +407,7 @@ inline NamedTupleDsvReader<Delimiter, NamedTuple>::NamedTupleDsvReader(
 template<char Delimiter, typename NamedTuple>
 inline bool
 NamedTupleDsvReader<Delimiter, NamedTuple>::read(NamedTuple& record) {
-  if (not m_reader.read(m_columns)) {
+  if (!m_reader.read(m_columns)) {
     return false;
   }
   // check for consistent entries per-line
@@ -431,7 +431,7 @@ inline bool
 NamedTupleDsvReader<Delimiter, NamedTuple>::read(
   NamedTuple& record, std::vector<T>& extra) {
   // parse columns belonging to the regular record
-  if (not read(record)) {
+  if (!read(record)) {
     return false;
   }
   // parse extra columns

--- a/dfe/dfe_io_numpy.hpp
+++ b/dfe/dfe_io_numpy.hpp
@@ -116,7 +116,7 @@ dtype_endianness_modifier() {
     char c[4];
   } x = {0x0A0B0C0D};
   bool is_little_endian =
-    (x.c[0] == 0xD) and (x.c[1] == 0xC) and (x.c[2] == 0xB) and (x.c[3] == 0xA);
+    (x.c[0] == 0xD) && (x.c[1] == 0xC) && (x.c[2] == 0xB) && (x.c[3] == 0xA);
   // TODO this assumes that only little and big endian exists and checks only
   // for little. maybe verify that it always is one or the other?
   return is_little_endian ? '<' : '>';

--- a/dfe/dfe_io_root.hpp
+++ b/dfe/dfe_io_root.hpp
@@ -130,13 +130,13 @@ inline NamedTupleRootWriter<NamedTuple>::NamedTupleRootWriter(
   const std::string& path, const std::string& tree_name)
   : m_file(new TFile(path.c_str(), "RECREATE"))
   , m_tree(new TTree(tree_name.c_str(), "", 99, m_file)) {
-  if (not m_file) {
+  if (!m_file) {
     throw std::runtime_error("Could not create file");
   }
-  if (not m_file->IsOpen()) {
+  if (!m_file->IsOpen()) {
     throw std::runtime_error("Could not open file");
   }
-  if (not m_tree) {
+  if (!m_tree) {
     throw std::runtime_error("Could not create tree");
   }
   setup_branches(std::make_index_sequence<std::tuple_size<Tuple>::value>());
@@ -147,10 +147,10 @@ inline NamedTupleRootWriter<NamedTuple>::NamedTupleRootWriter(
   TDirectory* dir, const std::string& tree_name)
   : m_file(nullptr) // no file since it is not owned by the writer
   , m_tree(new TTree(tree_name.c_str(), "", 99, dir)) {
-  if (not dir) {
+  if (!dir) {
     throw std::runtime_error("Invalid output directory given");
   }
-  if (not m_tree) {
+  if (!m_tree) {
     throw std::runtime_error("Could not create tree");
   }
   setup_branches(std::make_index_sequence<std::tuple_size<Tuple>::value>());
@@ -183,7 +183,7 @@ struct TypeCodeIntImpl {
 };
 template<typename T, std::size_t S>
 constexpr bool is_integer_with_size_v = std::is_integral<T>::value
-                                        and (sizeof(T) == S);
+                                        && (sizeof(T) == S);
 template<typename T>
 struct TypeCode<T, typename std::enable_if_t<is_integer_with_size_v<T, 1>>>
   : TypeCodeIntImpl<T, 'b', 'B'> {};
@@ -249,14 +249,14 @@ template<typename NamedTuple>
 inline NamedTupleRootReader<NamedTuple>::NamedTupleRootReader(
   const std::string& path, const std::string& tree_name)
   : m_file(new TFile(path.c_str(), "READ")), m_tree(nullptr), m_next(0) {
-  if (not m_file) {
+  if (!m_file) {
     throw std::runtime_error("Could not open file");
   }
-  if (not m_file->IsOpen()) {
+  if (!m_file->IsOpen()) {
     throw std::runtime_error("Could not open file");
   }
   m_tree = static_cast<TTree*>(m_file->Get(tree_name.c_str()));
-  if (not m_tree) {
+  if (!m_tree) {
     throw std::runtime_error("Could not read tree");
   }
   setup_branches(std::make_index_sequence<std::tuple_size<Tuple>::value>());
@@ -268,11 +268,11 @@ inline NamedTupleRootReader<NamedTuple>::NamedTupleRootReader(
   : m_file(nullptr) // no file since it is not owned by the writer
   , m_tree(nullptr)
   , m_next(0) {
-  if (not dir) {
+  if (!dir) {
     throw std::runtime_error("Invalid input directory given");
   }
   m_tree = static_cast<TTree*>(dir->Get(tree_name.c_str()));
-  if (not m_tree) {
+  if (!m_tree) {
     throw std::runtime_error("Could not read tree");
   }
   setup_branches(std::make_index_sequence<std::tuple_size<Tuple>::value>());

--- a/dfe/dfe_namedtuple.hpp
+++ b/dfe/dfe_namedtuple.hpp
@@ -36,6 +36,13 @@
 #include <tuple>
 #include <utility>
 
+// Set up a helper macro for not using a GCC extension on Windows.
+#ifdef _WIN32
+#define DFE_UNUSED
+#else
+#define DFE_UNUSED __attribute__((unused))
+#endif
+
 /// Enable tuple-like access and conversion for selected class/struct members.
 ///
 /// This allows access to the selected members via `.get<I>()` or `get<I>(...)`,
@@ -79,7 +86,7 @@
     return nt.template get<I>(); \
   } \
   friend inline ::std::ostream& operator<<(::std::ostream& os, const name& nt) \
-    __attribute__((unused)) { \
+    DFE_UNUSED { \
     return ::dfe::namedtuple_impl::print_tuple( \
       os, nt.names(), nt.tuple(), \
       ::std::make_index_sequence<::std::tuple_size<Tuple>::value>{}); \
@@ -95,18 +102,18 @@ namespace namedtuple_impl {
 template<std::size_t N>
 constexpr std::array<std::string, N>
 unstringify(const char* str) {
-  assert(str and "Input string must be non-null");
+  assert(str && "Input string must be non-null");
 
   std::array<std::string, N> out;
 
   for (std::size_t idx = 0; idx < N; ++idx) {
     // skip leading whitespace
-    while ((*str != '\0') and (*str == ' ')) {
+    while ((*str != '\0') && (*str == ' ')) {
       ++str;
     }
     // find the next separator or end-of-string
     const char* sep = str;
-    while ((*sep != '\0') and (*sep != ',')) {
+    while ((*sep != '\0') && (*sep != ',')) {
       ++sep;
     }
     // store component w/o the separator


### PR DESCRIPTION
These are some trivial replacements for:
  - `and` -> `&&`;
  - `or` -> `||`;
  - `not` -> `!`.

Plus one addition for hiding `__attribute__((unused))` on Windows.

This is needed to be able to use these headers with [MSVC](https://visualstudio.microsoft.com/vs/features/cplusplus/) out of the box.

@paulgessinger, how would you feel about making a new tag with this added? 🤔 